### PR TITLE
ADD new command line argument (-l)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,14 @@ FLAGS           := "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)"
 DISTRIBUTIONS   := ubuntu debian rhel centos opensuse sles amzn
 PACKAGE_TYPE    := deb rpm
 
+IMAGE_amzn     := "amazonlinux:2016.09"
+IMAGE_debian   := "debian:jessie"
+IMAGE_ubuntu   := "ubuntu:latest"
+IMAGE_rhel     := "richxsl/rhel7"
+IMAGE_centos   := "centos:7"
+IMAGE_opensuse := "opensuse"
+IMAGE_sles     := "gitlab.3fs.si:4567/tactycal/tactycal:sles12sp2"
+
 JFROG_URL      ?= https://bintray.com/api/v1
 JFROG_API_KEY  ?= THE_KEY
 JFROG_USERNAME ?= USERNAME
@@ -49,6 +57,9 @@ up/%: build ## starts the agent for a specific distribution
 	mkdir -p .state
 	touch .state/$*
 	docker-compose --project-name=tactycal up agent$*
+
+uplocal/%: build ## starts the agent for a specific distribution and prints the information to standard output
+	@docker run --rm -it -v $(PWD)/build/usr/bin/tactycal:/usr/bin/tactycal $(IMAGE_$*) /usr/bin/tactycal -l
 
 $(PKGDIR): $(addprefix $(PKGDIR)/,$(PACKAGE_TYPE)) ## creates artifacts for all distributions
 

--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ Additional command line arguments can be set when running Tactycal:
 | `-s string`   | `/var/opt/tactycal/state`  | path to where Tactycal can write its state |
 | `-t duration` |  `3s`                      | client timeout for request in seconds (check [Go's documentation](https://golang.org/pkg/time/#ParseDuration) for notation) |
 | `-v`          |                            | print version and exit |
+| `-l`          | `false`                    | print host information and installed packages to standard output as `json` string and exit |

--- a/local.go
+++ b/local.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/tactycal/agent/packageLookup"
+)
+
+// local returns host information and installed packages as json string
+func local() (string, error) {
+	host, err := GetHostInfo()
+	if err != nil {
+		return "", err
+	}
+
+	packages, err := packageLookup.Get(host.Distribution)
+	if err != nil {
+		return "", err
+	}
+
+	b, err := json.Marshal(&SendPackagesRequestBody{host, packages})
+	return string(b), err
+}

--- a/local_test.go
+++ b/local_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tactycal/agent/stubUtils"
+)
+
+func TestLocal(t *testing.T) {
+	s := stubUtils.NewStubs(t,
+		&stubUtils.ReadFileStub{Path: "/etc/os-release", Output: []byte("ID=amzn\nVERSION_ID=\"2016.09\"")},
+		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-m"}, Output: []byte("ARCH")},
+		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-r"}, Output: []byte("KERN")},
+		&stubUtils.CmdStub{Cmd: "hostname", Args: []string{"-f"}, Output: []byte("FQDN")},
+		&stubUtils.CmdStub{Cmd: "rpm", Args: []string{`-qa`, `--queryformat`,
+			`Name: %{NAME}\nArchitecture: %{ARCH}\nVersion: %{VERSION}\nRelease: %{RELEASE}\nVendor: %{VENDOR}\nSource: %{SOURCERPM}\nEpoch: %{EPOCH}\n\n`},
+			Output: []byte("Name: libverto\nArchitecture: x86_64\nVersion: 0.2.5\nRelease: 4.9\nVendor: unknown\nSource: libverto-0.2.5-4.9.src.rpm\nEpoch: (none)")},
+	)
+	defer s.Close()
+
+	expected := `{"fqdn":"FQDN","distribution":"amzn","release":"2016.09","architecture":"ARCH","kernel":"KERN","labels":null,"packages":[{"name":"libverto","version":"0.2.5-4.9","source":"libverto","architecture":"x86_64","official":false}]}`
+
+	// 1. ok
+	result, _ := local()
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Result\n%s\ndoesn't match expected\n%s\n", result, expected)
+	}
+
+	// 2. error expected from get host info
+	s.Add(&stubUtils.ReadFileStub{Path: "/etc/os-release", Err: stubUtils.OhNoErr})
+
+	_, err := local()
+	if err == nil {
+		t.Error("An error was expected")
+	}
+
+	// 3. error is expected from packageLookup
+	s.Add(&stubUtils.ReadFileStub{Path: "/etc/os-release", Output: []byte("ID=amzn\nVERSION_ID=\"2016.09\"")},
+		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-m"}, Output: []byte("ARCH")},
+		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-r"}, Output: []byte("KERN")},
+		&stubUtils.CmdStub{Cmd: "hostname", Args: []string{"-f"}, Output: []byte("FQDN")},
+		&stubUtils.CmdStub{Cmd: "rpm", Args: []string{`-qa`, `--queryformat`,
+			`Name: %{NAME}\nArchitecture: %{ARCH}\nVersion: %{VERSION}\nRelease: %{RELEASE}\nVendor: %{VENDOR}\nSource: %{SOURCERPM}\nEpoch: %{EPOCH}\n\n`},
+			Err: stubUtils.OhNoErr},
+	)
+
+	_, err = local()
+	if err == nil {
+		t.Error("An error was expected")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,10 +13,22 @@ func main() {
 	debugMode := flag.Bool("d", false, "show debug messages")
 	statePath := flag.String("s", DefaultStatePath, "path to where tactycal can write its state")
 	clientTimeout := flag.Duration("t", DefaultClientTimeout, "client timeout for request in seconds")
+	localOutput := flag.Bool("l", false, "print host information and installed packages to standard output as json string and exit")
+
 	flag.Parse()
 
 	if *showVersion {
 		fmt.Printf("tactycal %s-%s\n", Version, GitCommit)
+		return
+	}
+
+	if *localOutput {
+		if s, err := local(); err != nil {
+			fmt.Printf("Failed to retrieved host information and installed packages; %s", err.Error())
+		} else {
+			fmt.Println(s)
+		}
+
 		return
 	}
 

--- a/osDiscovery/osDiscovery.go
+++ b/osDiscovery/osDiscovery.go
@@ -14,6 +14,7 @@ package osDiscovery
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/tactycal/agent/stubUtils"
 )
@@ -102,7 +103,7 @@ func GetDistributionRelease() (string, string, error) {
 // GetArchitecture returns a machine hardware name.
 func GetArchitecture() (string, error) {
 	if out, err := stubUtils.ExecCommand("uname", "-m"); err == nil {
-		return string(out), nil
+		return strings.TrimSuffix(string(out), "\n"), nil
 	}
 	return "", ErrUnknownArchitecture
 }
@@ -110,7 +111,7 @@ func GetArchitecture() (string, error) {
 // GetKernel returns a kernel release.
 func GetKernel() (string, error) {
 	if out, err := stubUtils.ExecCommand("uname", "-r"); err == nil {
-		return string(out), nil
+		return strings.TrimSuffix(string(out), "\n"), nil
 	}
 	return "", ErrUnknownKernel
 }
@@ -118,11 +119,11 @@ func GetKernel() (string, error) {
 // GetFqdn returns the fully qualified domain name (FQDN).
 func GetFqdn() (string, error) {
 	if out, err := stubUtils.ExecCommand("hostname", "-f"); err == nil {
-		return string(out), nil
+		return strings.TrimSuffix(string(out), "\n"), nil
 	}
 
 	if out, err := stubUtils.ReadFile("/etc/hostname"); err == nil {
-		return string(out), nil
+		return strings.TrimSuffix(string(out), "\n"), nil
 	}
 
 	return "", ErrUnknownFqdn

--- a/osDiscovery/osDiscovery_test.go
+++ b/osDiscovery/osDiscovery_test.go
@@ -157,24 +157,32 @@ func TestGetFqdn(t *testing.T) {
 		t.Errorf("Expected \"host\"; got %s", out)
 	}
 
-	// 2: file
+	// 2: new line
+	s.Add(&stubUtils.CmdStub{Cmd: "hostname", Args: []string{"-f"}, Output: []byte("HOST\n")})
+	if out, _ := GetFqdn(); out != "HOST" {
+		t.Errorf("Expected \"host\"; got %s", out)
+	}
+
+	// 3: file
 	s.Add(&stubUtils.CmdStub{Cmd: "hostname", Args: []string{"-f"}, Err: stubUtils.OhNoErr},
 		&stubUtils.ReadFileStub{Path: "/etc/hostname", Output: []byte("HOST")})
 	if out, _ := GetFqdn(); out != "HOST" {
 		t.Errorf("Expected \"host\"; got %s", out)
 	}
 
-	// 3: unknown
+	// 4: unknown
 	s.Add(&stubUtils.CmdStub{Cmd: "hostname", Args: []string{"-f"}, Err: stubUtils.OhNoErr},
 		&stubUtils.ReadFileStub{Path: "/etc/hostname", Err: stubUtils.OhNoErr})
 	if _, err := GetFqdn(); err != ErrUnknownFqdn {
 		t.Errorf("Expected error \"%s\"; got %s", ErrUnknownFqdn.Error(), err.Error())
 	}
+
 }
 
 func TestGetArchitecture(t *testing.T) {
 	s := stubUtils.NewStubs(t,
 		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-m"}, Output: []byte("ARCH")},
+		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-m"}, Output: []byte("ARCH\n")},
 		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-m"}, Err: stubUtils.OhNoErr})
 	defer s.Close()
 
@@ -183,25 +191,38 @@ func TestGetArchitecture(t *testing.T) {
 		t.Errorf("Expected \"arch\"; got %s", out)
 	}
 
-	// 2:  unknown
+	// 2: new line
+	if out, _ := GetArchitecture(); out != "ARCH" {
+		t.Errorf("Expected \"arch\"; got %s", out)
+	}
+
+	// 3:  unknown
 	if _, err := GetArchitecture(); err != ErrUnknownArchitecture {
 		t.Errorf("Expected error \"%s\"; got %s", ErrUnknownArchitecture.Error(), err.Error())
 	}
+
 }
 
 func TestGetKernel(t *testing.T) {
 	s := stubUtils.NewStubs(t,
 		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-r"}, Output: []byte("KERN")},
+		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-r"}, Output: []byte("KERN\n")},
 		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-r"}, Err: stubUtils.OhNoErr})
 	defer s.Close()
 
 	// 1: all good
 	if out, _ := GetKernel(); out != "KERN" {
-		t.Errorf("Expected \"arch\"; got %s", out)
+		t.Errorf("Expected \"kern\"; got %s", out)
 	}
 
-	// 2:  unknown
+	// 2: new line
+	if out, _ := GetKernel(); out != "KERN" {
+		t.Errorf("Expected \"kern\"; got %s", out)
+	}
+
+	// 3:  unknown
 	if _, err := GetKernel(); err != ErrUnknownKernel {
 		t.Errorf("Expected error \"%s\"; got %s", ErrUnknownKernel.Error(), err.Error())
 	}
+
 }


### PR DESCRIPTION
Tactycal agent can now print host information and installed
packages to  standard output instead to send it to Tactycal
service. To print those information to standard output just
run Tactycal agent with `-l` flag (`/usr/bin/tactycal -l`)
or `make uplocal/distribution` (`make uplocal/amzn`).