### PR TITLE
FIX remove unwanted n in some output(arch, kernel and fqdn)

### DIFF
--- a/osDiscovery/osDiscovery.go
+++ b/osDiscovery/osDiscovery.go
@@ -14,6 +14,7 @@ package osDiscovery
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/tactycal/agent/stubUtils"
 )
@@ -102,7 +103,7 @@ func GetDistributionRelease() (string, string, error) {
 // GetArchitecture returns a machine hardware name.
 func GetArchitecture() (string, error) {
 	if out, err := stubUtils.ExecCommand("uname", "-m"); err == nil {
-		return string(out), nil
+		return strings.TrimSuffix(string(out), "\n"), nil
 	}
 	return "", ErrUnknownArchitecture
 }
@@ -110,7 +111,7 @@ func GetArchitecture() (string, error) {
 // GetKernel returns a kernel release.
 func GetKernel() (string, error) {
 	if out, err := stubUtils.ExecCommand("uname", "-r"); err == nil {
-		return string(out), nil
+		return strings.TrimSuffix(string(out), "\n"), nil
 	}
 	return "", ErrUnknownKernel
 }
@@ -118,11 +119,11 @@ func GetKernel() (string, error) {
 // GetFqdn returns the fully qualified domain name (FQDN).
 func GetFqdn() (string, error) {
 	if out, err := stubUtils.ExecCommand("hostname", "-f"); err == nil {
-		return string(out), nil
+		return strings.TrimSuffix(string(out), "\n"), nil
 	}
 
 	if out, err := stubUtils.ReadFile("/etc/hostname"); err == nil {
-		return string(out), nil
+		return strings.TrimSuffix(string(out), "\n"), nil
 	}
 
 	return "", ErrUnknownFqdn

--- a/osDiscovery/osDiscovery_test.go
+++ b/osDiscovery/osDiscovery_test.go
@@ -157,24 +157,32 @@ func TestGetFqdn(t *testing.T) {
 		t.Errorf("Expected \"host\"; got %s", out)
 	}
 
-	// 2: file
+	// 2: new line
+	s.Add(&stubUtils.CmdStub{Cmd: "hostname", Args: []string{"-f"}, Output: []byte("HOST\n")})
+	if out, _ := GetFqdn(); out != "HOST" {
+		t.Errorf("Expected \"host\"; got %s", out)
+	}
+
+	// 3: file
 	s.Add(&stubUtils.CmdStub{Cmd: "hostname", Args: []string{"-f"}, Err: stubUtils.OhNoErr},
 		&stubUtils.ReadFileStub{Path: "/etc/hostname", Output: []byte("HOST")})
 	if out, _ := GetFqdn(); out != "HOST" {
 		t.Errorf("Expected \"host\"; got %s", out)
 	}
 
-	// 3: unknown
+	// 4: unknown
 	s.Add(&stubUtils.CmdStub{Cmd: "hostname", Args: []string{"-f"}, Err: stubUtils.OhNoErr},
 		&stubUtils.ReadFileStub{Path: "/etc/hostname", Err: stubUtils.OhNoErr})
 	if _, err := GetFqdn(); err != ErrUnknownFqdn {
 		t.Errorf("Expected error \"%s\"; got %s", ErrUnknownFqdn.Error(), err.Error())
 	}
+
 }
 
 func TestGetArchitecture(t *testing.T) {
 	s := stubUtils.NewStubs(t,
 		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-m"}, Output: []byte("ARCH")},
+		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-m"}, Output: []byte("ARCH\n")},
 		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-m"}, Err: stubUtils.OhNoErr})
 	defer s.Close()
 
@@ -183,25 +191,38 @@ func TestGetArchitecture(t *testing.T) {
 		t.Errorf("Expected \"arch\"; got %s", out)
 	}
 
-	// 2:  unknown
+	// 2: new line
+	if out, _ := GetArchitecture(); out != "ARCH" {
+		t.Errorf("Expected \"arch\"; got %s", out)
+	}
+
+	// 3:  unknown
 	if _, err := GetArchitecture(); err != ErrUnknownArchitecture {
 		t.Errorf("Expected error \"%s\"; got %s", ErrUnknownArchitecture.Error(), err.Error())
 	}
+
 }
 
 func TestGetKernel(t *testing.T) {
 	s := stubUtils.NewStubs(t,
 		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-r"}, Output: []byte("KERN")},
+		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-r"}, Output: []byte("KERN\n")},
 		&stubUtils.CmdStub{Cmd: "uname", Args: []string{"-r"}, Err: stubUtils.OhNoErr})
 	defer s.Close()
 
 	// 1: all good
 	if out, _ := GetKernel(); out != "KERN" {
-		t.Errorf("Expected \"arch\"; got %s", out)
+		t.Errorf("Expected \"kern\"; got %s", out)
 	}
 
-	// 2:  unknown
+	// 2: new line
+	if out, _ := GetKernel(); out != "KERN" {
+		t.Errorf("Expected \"kern\"; got %s", out)
+	}
+
+	// 3:  unknown
 	if _, err := GetKernel(); err != ErrUnknownKernel {
 		t.Errorf("Expected error \"%s\"; got %s", ErrUnknownKernel.Error(), err.Error())
 	}
+
 }


### PR DESCRIPTION
Agent no longer generates new line characters in json output at the end of architecture, kernel and fqdn