### PR TITLE
FIX [packageLookup] setOfficialApt for packages with the same name

### DIFF
--- a/packageLookup/apt.go
+++ b/packageLookup/apt.go
@@ -69,7 +69,7 @@ func setOfficialApt(aptMaintainerRe, aptPatchRe *regexp.Regexp, packages []*Pack
 	}
 
 	// collect package repositories
-	policy, err := getAptCachePolicy(getNameOfPackages(packages))
+	policy, err := getAptCachePolicy(getNamesOfPackages(packages))
 	if err != nil {
 		return err
 	}
@@ -100,8 +100,8 @@ func setOfficialApt(aptMaintainerRe, aptPatchRe *regexp.Regexp, packages []*Pack
 	return nil
 }
 
-// getNameOfPackages returns the name of the packages
-func getNameOfPackages(packages []*Package) []string {
+// getNamesOfPackages returns the name of the packages
+func getNamesOfPackages(packages []*Package) []string {
 	list := []string{}
 	for _, pkg := range packages {
 		list = append(list, pkg.Name)

--- a/packageLookup/apt.go
+++ b/packageLookup/apt.go
@@ -16,7 +16,7 @@ const (
 	aptPatchDebian      = "\\+deb\\d+u\\d+$"
 )
 
-// returns packages for distribution using a APT package manager
+// getApt returns packages for distribution using a APT package manager
 func getApt(aptMaintainer, aptPatch string) ([]*Package, error) {
 	// read status of all installed packages
 	data, err := stubUtils.ReadFile(dpkgStatusPath)
@@ -28,7 +28,6 @@ func getApt(aptMaintainer, aptPatch string) ([]*Package, error) {
 	packages := strings.Split(string(data), "\n\n")
 
 	result := []*Package{}
-	officialMap := map[string]*Package{}
 	// pattern for all key=value would be "([a-zA-Z-]+): ?(.*)"
 	reKV := regexp.MustCompile("(Status|Package|Version|Architecture|Source|Maintainer): (.*)")
 	// iterate through packages and collect the data
@@ -51,19 +50,18 @@ func getApt(aptMaintainer, aptPatch string) ([]*Package, error) {
 				Source:       extractPackageNameFromSource(matches["Source"]),
 			}
 			result = append(result, pkg)
-			officialMap[matches["Package"]] = pkg
 		}
 	}
 
 	// check for official packages
-	if err := setOfficialApt(regexp.MustCompile(aptMaintainer), regexp.MustCompile(aptPatch), officialMap); err != nil {
+	if err := setOfficialApt(regexp.MustCompile(aptMaintainer), regexp.MustCompile(aptPatch), result); err != nil {
 		return nil, err
 	}
 
 	return result, nil
 }
 
-func setOfficialApt(aptMaintainerRe, aptPatchRe *regexp.Regexp, officialMap map[string]*Package) error {
+func setOfficialApt(aptMaintainerRe, aptPatchRe *regexp.Regexp, packages []*Package) error {
 	// get "official" repositories
 	officialRepos, err := getRepositoriesFromSourcesList()
 	if err != nil {
@@ -71,15 +69,15 @@ func setOfficialApt(aptMaintainerRe, aptPatchRe *regexp.Regexp, officialMap map[
 	}
 
 	// collect package repositories
-	policy, err := getAptCachePolicy(officialMapToList(officialMap))
+	policy, err := getAptCachePolicy(getNameOfPackages(packages))
 	if err != nil {
 		return err
 	}
 
 	// iterate over packages
-	for pkgName, pkg := range officialMap {
+	for _, pkg := range packages {
 		// 1. check the source
-		if sources, ok := policy[pkgName]; ok {
+		if sources, ok := policy[pkg.Name]; ok {
 			if isPackageSourceFromOfficialRepositories(sources, officialRepos) {
 				pkg.Official = true
 				continue
@@ -102,11 +100,11 @@ func setOfficialApt(aptMaintainerRe, aptPatchRe *regexp.Regexp, officialMap map[
 	return nil
 }
 
-// extract keys from the map of all packages
-func officialMapToList(officialMap map[string]*Package) []string {
+// getNameOfPackages returns the name of the packages
+func getNameOfPackages(packages []*Package) []string {
 	list := []string{}
-	for pkgName, _ := range officialMap {
-		list = append(list, pkgName)
+	for _, pkg := range packages {
+		list = append(list, pkg.Name)
 	}
 	return list
 }

--- a/packageLookup/apt_test.go
+++ b/packageLookup/apt_test.go
@@ -15,36 +15,43 @@ func TestGetPackages(t *testing.T) {
 		&stubUtils.CmdStub{Cmd: "apt-cache", StubFile: "testdata/ubuntu_apt_cache"})
 	defer s.Close()
 
-	expectedResult := map[string]*Package{
-		"gtk2-engines-murrine": &Package{
+	expectedResult := []*Package{
+		&Package{
 			Name:         "gtk2-engines-murrine",
 			Version:      "0.98.2-0ubuntu1",
 			Architecture: "i386",
 			maintainer:   "Ubuntu Core Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
 			Official:     true,
 		},
-		"skype": &Package{
+		&Package{
+			Name:         "gtk2-engines-murrine",
+			Version:      "0.98.2-0ubuntu1",
+			Architecture: "amd64",
+			maintainer:   "Ubuntu Core Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+			Official:     true,
+		},
+		&Package{
 			Name:         "skype",
 			Version:      "4.2.0.11-1",
 			Architecture: "i386",
 			maintainer:   "Skype Technologies <info@skype.net>",
 			Official:     false,
 		},
-		"apt": &Package{
+		&Package{
 			Name:         "apt",
 			Version:      "0.8.16~exp12ubuntu10.27",
 			maintainer:   "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
 			Architecture: "amd64",
 			Official:     true,
 		},
-		"oracle-java8-installer": &Package{
+		&Package{
 			Name:         "oracle-java8-installer",
 			Version:      "8u111+8u111arm-1~webupd8~0",
 			maintainer:   "Alin Andrei <webupd8@gmail.com>",
 			Architecture: "all",
 			Official:     false,
 		},
-		"apt-xapian-index": &Package{
+		&Package{
 			Name:         "apt-xapian-index",
 			Version:      "0.44ubuntu5.1",
 			maintainer:   "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
@@ -60,23 +67,8 @@ func TestGetPackages(t *testing.T) {
 		t.Errorf("Expected error to bi nil; got %v", err)
 	}
 
-	// check if numbers of packages match
-	if len(result) != len(expectedResult) {
-		t.Errorf("Number of packages %d doesn't match expected %d", len(result), len(expectedResult))
-	}
-
-	// check if packages match
-	for _, v := range result {
-		// check if expected result contain package
-		expectedV, ok := expectedResult[v.Name]
-		if !ok {
-			t.Errorf("Package %s is not expected", v.Name)
-			continue
-		}
-
-		if !reflect.DeepEqual(expectedV, v) {
-			t.Errorf("Result\n%+v\ndoesn't match expected\n%+v\n", v, expectedV)
-		}
+	if !reflect.DeepEqual(result, expectedResult) {
+		t.Errorf("Result\n%+v\ndoesn't match expected\n%+v\n", result, expectedResult)
 	}
 }
 
@@ -124,15 +116,15 @@ func TestGetRepositoriesFromSourcesList(t *testing.T) {
 }
 
 func TestOfficialMapToList(t *testing.T) {
-	testCase := map[string]*Package{
-		"Package": &Package{
+	testCase := []*Package{
+		&Package{
 			Name: "Package",
 		},
 	}
 
 	expectedResult := []string{"Package"}
 
-	result := officialMapToList(testCase)
+	result := getNameOfPackages(testCase)
 
 	if !reflect.DeepEqual(result, expectedResult) {
 		t.Errorf("Result\n%+v\ndoesn't match expected\n%+v\n", result, expectedResult)
@@ -260,14 +252,14 @@ func TestSetOfficialApt(t *testing.T) {
 		&stubUtils.CmdStub{Cmd: "apt-cache", StubFile: "testdata/ubuntu_apt_cache"})
 	defer s.Close()
 
-	testCase := map[string]*Package{
-		"gtk2-engines-murrine": &Package{
+	testCase := []*Package{
+		&Package{
 			Name:         "gtk2-engines-murrine",
 			Version:      "0.98.2-0ubuntu1",
 			Architecture: "i386",
 			maintainer:   "Ubuntu Core Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
 		},
-		"skype": &Package{
+		&Package{
 			Name:         "skype",
 			Version:      "4.2.0.11-1",
 			Architecture: "i386",
@@ -275,15 +267,15 @@ func TestSetOfficialApt(t *testing.T) {
 		},
 	}
 
-	expectedResult := map[string]*Package{
-		"gtk2-engines-murrine": &Package{
+	expectedResult := []*Package{
+		&Package{
 			Name:         "gtk2-engines-murrine",
 			Version:      "0.98.2-0ubuntu1",
 			Architecture: "i386",
 			maintainer:   "Ubuntu Core Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
 			Official:     true,
 		},
-		"skype": &Package{
+		&Package{
 			Name:         "skype",
 			Version:      "4.2.0.11-1",
 			Architecture: "i386",

--- a/packageLookup/apt_test.go
+++ b/packageLookup/apt_test.go
@@ -115,7 +115,7 @@ func TestGetRepositoriesFromSourcesList(t *testing.T) {
 	}
 }
 
-func TestOfficialMapToList(t *testing.T) {
+func TestGetNameOfPackages(t *testing.T) {
 	testCase := []*Package{
 		&Package{
 			Name: "Package",

--- a/packageLookup/apt_test.go
+++ b/packageLookup/apt_test.go
@@ -115,7 +115,7 @@ func TestGetRepositoriesFromSourcesList(t *testing.T) {
 	}
 }
 
-func TestgetNamesOfPackages(t *testing.T) {
+func TestGetNamesOfPackages(t *testing.T) {
 	testCase := []*Package{
 		&Package{
 			Name: "Package",

--- a/packageLookup/apt_test.go
+++ b/packageLookup/apt_test.go
@@ -115,7 +115,7 @@ func TestGetRepositoriesFromSourcesList(t *testing.T) {
 	}
 }
 
-func TestGetNameOfPackages(t *testing.T) {
+func TestgetNamesOfPackages(t *testing.T) {
 	testCase := []*Package{
 		&Package{
 			Name: "Package",
@@ -124,7 +124,7 @@ func TestGetNameOfPackages(t *testing.T) {
 
 	expectedResult := []string{"Package"}
 
-	result := getNameOfPackages(testCase)
+	result := getNamesOfPackages(testCase)
 
 	if !reflect.DeepEqual(result, expectedResult) {
 		t.Errorf("Result\n%+v\ndoesn't match expected\n%+v\n", result, expectedResult)

--- a/packageLookup/testdata/ubuntu_status
+++ b/packageLookup/testdata/ubuntu_status
@@ -10,6 +10,18 @@ Version: 0.98.2-0ubuntu1
 Depends: libc6 (>= 2.4), libcairo2 (>= 1.2.4), libgdk-pixbuf2.0-0 (>= 2.22.0), libglib2.0-0 (>= 2.24.0), libgtk2.0-0 (>= 2.24.5-4), libpango1.0-0 (>= 1.14.0), libpixman-1-0 (>= 0.15.14)
 Suggests: murrine-themes (>= 0.98)
 
+Package: gtk2-engines-murrine
+Status: install ok installed
+Multi-Arch: same
+Priority: optional
+Section: x11
+Installed-Size: 330
+Maintainer: Ubuntu Core Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+Architecture: amd64
+Version: 0.98.2-0ubuntu1
+Depends: libc6 (>= 2.4), libcairo2 (>= 1.2.4), libgdk-pixbuf2.0-0 (>= 2.22.0), libglib2.0-0 (>= 2.24.0), libgtk2.0-0 (>= 2.24.5-4), libpango1.0-0 (>= 1.14.0), libpixman-1-0 (>= 0.15.14)
+Suggests: murrine-themes (>= 0.98)
+
 Package: skype
 Status: install ok installed
 Priority: extra


### PR DESCRIPTION
If two or more "apt" packages have the same name, then an
official field has has been set only for the last on the list.
Now all "apt" packages go through checking process.